### PR TITLE
Remove edlib orientation path

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -23,23 +23,13 @@ version = "0.1.0"
 dependencies = [
  "atty",
  "bio",
- "clap 4.5.41",
- "edlib_rs",
+ "clap",
  "indicatif",
  "lib_wfa2",
  "noodles",
  "rand",
  "rayon",
  "tempfile",
-]
-
-[[package]]
-name = "ansi_term"
-version = "0.12.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d52a9bb7ec0cf484c551830a7ce27bd20d67eac647e1befb56b0be4ee39a55d2"
-dependencies = [
- "winapi",
 ]
 
 [[package]]
@@ -125,30 +115,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
-name = "bindgen"
-version = "0.55.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75b13ce559e6433d360c26305643803cb52cfbabbc2b9c47ce04a58493dfb443"
-dependencies = [
- "bitflags 1.3.2",
- "cexpr",
- "cfg-if 0.1.10",
- "clang-sys",
- "clap 2.34.0",
- "env_logger",
- "lazy_static",
- "lazycell",
- "log",
- "peeking_take_while",
- "proc-macro2",
- "quote",
- "regex",
- "rustc-hash",
- "shlex 0.1.1",
- "which",
-]
-
-[[package]]
 name = "bio"
 version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -217,12 +183,6 @@ checksum = "349f9b6a179ed607305526ca489b34ad0a41aed5f7980fa90eb03160b69598fb"
 
 [[package]]
 name = "bitflags"
-version = "1.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
-
-[[package]]
-name = "bitflags"
 version = "2.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1b8e56985ec62d17e9c1001dc89c88ecd7dc08e47eba5ec7c29c7b5eeecde967"
@@ -235,16 +195,6 @@ checksum = "234113d19d0d7d613b40e86fb654acf958910802bcceab913a4f9e7cda03b1a4"
 dependencies = [
  "memchr",
  "serde",
-]
-
-[[package]]
-name = "buf_redux"
-version = "0.8.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b953a6887648bb07a535631f2bc00fbdb2a2216f135552cb3f534ed136b9c07f"
-dependencies = [
- "memchr",
- "safemem",
 ]
 
 [[package]]
@@ -288,80 +238,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d71b6127be86fdcfddb610f7182ac57211d4b18a3e9c82eb2d17662f2227ad6a"
 
 [[package]]
-name = "bzip2"
-version = "0.4.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bdb116a6ef3f6c3698828873ad02c3014b3c85cadb88496095628e3ef1e347f8"
-dependencies = [
- "bzip2-sys",
- "libc",
-]
-
-[[package]]
-name = "bzip2-sys"
-version = "0.1.13+1.0.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "225bff33b2141874fe80d71e07d6eec4f85c5c216453dd96388240f96e1acc14"
-dependencies = [
- "cc",
- "pkg-config",
-]
-
-[[package]]
-name = "cc"
-version = "1.2.29"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c1599538de2394445747c8cf7935946e3cc27e9625f889d979bfb2aaf569362"
-dependencies = [
- "shlex 1.3.0",
-]
-
-[[package]]
-name = "cexpr"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4aedb84272dbe89af497cf81375129abda4fc0a9e7c5d317498c15cc30c0d27"
-dependencies = [
- "nom",
-]
-
-[[package]]
-name = "cfg-if"
-version = "0.1.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4785bdd1c96b2a846b2bd7cc02e86b6b3dbf14e7e53446c4f54c92a361040822"
-
-[[package]]
 name = "cfg-if"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9555578bc9e57714c812a1f84e4fc5b4d21fcb063490c624de019f7464c91268"
-
-[[package]]
-name = "clang-sys"
-version = "1.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b023947811758c97c59bf9d1c188fd619ad4718dcaa767947df1cadb14f39f4"
-dependencies = [
- "glob",
- "libc",
- "libloading",
-]
-
-[[package]]
-name = "clap"
-version = "2.34.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a0610544180c38b88101fecf2dd634b174a62eef6946f84dfc6a7127512b381c"
-dependencies = [
- "ansi_term",
- "atty",
- "bitflags 1.3.2",
- "strsim 0.8.0",
- "textwrap",
- "unicode-width 0.1.14",
- "vec_map",
-]
 
 [[package]]
 name = "clap"
@@ -382,7 +262,7 @@ dependencies = [
  "anstream",
  "anstyle",
  "clap_lex",
- "strsim 0.11.1",
+ "strsim",
 ]
 
 [[package]]
@@ -404,15 +284,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b94f61472cee1439c0b966b47e3aca9ae07e45d070759512cd390ea2bebc6675"
 
 [[package]]
-name = "cmake"
-version = "0.1.54"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e7caa3f9de89ddbe2c607f4101924c5abec803763ae9534e4f4d7d8f84aa81f0"
-dependencies = [
- "cc",
-]
-
-[[package]]
 name = "colorchoice"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -427,18 +298,8 @@ dependencies = [
  "encode_unicode",
  "libc",
  "once_cell",
- "unicode-width 0.2.1",
+ "unicode-width",
  "windows-sys",
-]
-
-[[package]]
-name = "cpu-time"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e9e393a7668fe1fad3075085b86c781883000b4ede868f43627b34a87c8b7ded"
-dependencies = [
- "libc",
- "winapi",
 ]
 
 [[package]]
@@ -447,7 +308,7 @@ version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a97769d94ddab943e4510d138150169a2758b5ef3eb191a9ee688de3e23ef7b3"
 dependencies = [
- "cfg-if 1.0.1",
+ "cfg-if",
 ]
 
 [[package]]
@@ -529,22 +390,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3e02df23d5b1c6f9e69fa603b890378123b93073df998a21e6e33b9db0a32613"
 
 [[package]]
-name = "edlib_rs"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32f35d33867b621dfe7e9db6e79c64b7e09f724d316ccd140df120e74c8e1aab"
-dependencies = [
- "bindgen",
- "clap 2.34.0",
- "cmake",
- "cpu-time",
- "env_logger",
- "lazy_static",
- "log",
- "needletail",
-]
-
-[[package]]
 name = "either"
 version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -574,19 +419,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.104",
-]
-
-[[package]]
-name = "env_logger"
-version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44533bbbb3bb3c1fa17d9f2e4e38bbbaf8396ba82193c4cb1b6445d711445d36"
-dependencies = [
- "atty",
- "humantime",
- "log",
- "regex",
- "termcolor",
 ]
 
 [[package]]
@@ -649,7 +481,7 @@ version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "335ff9f135e4384c8150d6f27c6daed433577f86b4750418338c01a1a2528592"
 dependencies = [
- "cfg-if 1.0.1",
+ "cfg-if",
  "libc",
  "wasi 0.11.1+wasi-snapshot-preview1",
 ]
@@ -660,17 +492,11 @@ version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "26145e563e54f2cadc477553f1ec5ee650b00862f0a58bcd12cbdc5f0ea2d2f4"
 dependencies = [
- "cfg-if 1.0.1",
+ "cfg-if",
  "libc",
  "r-efi",
  "wasi 0.14.2+wasi-0.2.4",
 ]
-
-[[package]]
-name = "glob"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8d1add55171497b4705a648c6b583acafb01d58050a51727785f0b2c8e0a2b2"
 
 [[package]]
 name = "hashbrown"
@@ -700,15 +526,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "humantime"
-version = "1.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df004cfca50ef23c36850aaaa59ad52cc70d0e90243c3c7737a4dd32dc7a3c4f"
-dependencies = [
- "quick-error",
-]
-
-[[package]]
 name = "indexmap"
 version = "2.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -728,7 +545,7 @@ dependencies = [
  "number_prefix",
  "portable-atomic",
  "rayon",
- "unicode-width 0.2.1",
+ "unicode-width",
  "web-time",
 ]
 
@@ -779,12 +596,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
-name = "lazycell"
-version = "1.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
-
-[[package]]
 name = "lib_wfa2"
 version = "0.1.0"
 source = "git+https://github.com/ekg/lib_wfa2?rev=819b82cd842aabedcb962fd5b82380fe454234f6#819b82cd842aabedcb962fd5b82380fe454234f6"
@@ -794,16 +605,6 @@ name = "libc"
 version = "0.2.174"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1171693293099992e19cddea4e8b849964e9846f4acee11b3948bcc337be8776"
-
-[[package]]
-name = "libloading"
-version = "0.8.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07033963ba89ebaf1584d767badaa2e8fcec21aedea6b8c0346d487d49c28667"
-dependencies = [
- "cfg-if 1.0.1",
- "windows-targets",
-]
 
 [[package]]
 name = "libm"
@@ -831,17 +632,6 @@ name = "log"
 version = "0.4.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13dc2df351e3202783a1fe0d44375f7295ffb4049267b0f3018346dc122a1d94"
-
-[[package]]
-name = "lzma-sys"
-version = "0.1.20"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5fda04ab3764e6cde78b9974eec4f779acaba7c4e84b36eca3cf77c581b85d27"
-dependencies = [
- "cc",
- "libc",
- "pkg-config",
-]
 
 [[package]]
 name = "matrixmultiply"
@@ -920,36 +710,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "needletail"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7fb4c43ebd04b0e776119c8fc3bd4c28178619cd04e1f19f600a4ef0282fa3cc"
-dependencies = [
- "buf_redux",
- "bytecount",
- "bzip2",
- "flate2",
- "memchr",
- "xz2",
-]
-
-[[package]]
 name = "newtype_derive"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac8cd24d9f185bb7223958d8c1ff7a961b74b1953fd05dba7cc568a63b3861ec"
 dependencies = [
  "rustc_version",
-]
-
-[[package]]
-name = "nom"
-version = "5.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08959a387a676302eebf4ddbcbc611da04285579f76f88ee0506c63b1a61dd4b"
-dependencies = [
- "memchr",
- "version_check",
 ]
 
 [[package]]
@@ -1068,12 +834,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
 
 [[package]]
-name = "peeking_take_while"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19b17cddbe7ec3f8bc800887bab5e717348c95ea2ca0b1bf0837fb964dc67099"
-
-[[package]]
 name = "petgraph"
 version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1082,12 +842,6 @@ dependencies = [
  "fixedbitset",
  "indexmap",
 ]
-
-[[package]]
-name = "pkg-config"
-version = "0.3.32"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
 
 [[package]]
 name = "portable-atomic"
@@ -1112,12 +866,6 @@ checksum = "02b3e5e68a3a1a02aad3ec490a98007cbc13c37cbe84a3cd7b8e406d76e7f778"
 dependencies = [
  "unicode-ident",
 ]
-
-[[package]]
-name = "quick-error"
-version = "1.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
 
 [[package]]
 name = "quote"
@@ -1230,12 +978,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
 
 [[package]]
-name = "rustc-hash"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
-
-[[package]]
 name = "rustc_version"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1250,7 +992,7 @@ version = "1.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "11181fbabf243db407ef8df94a6ce0b2f9a733bd8be4ad02b4eda9602296cac8"
 dependencies = [
- "bitflags 2.9.1",
+ "bitflags",
  "errno",
  "libc",
  "linux-raw-sys",
@@ -1279,12 +1021,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "safemem"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef703b7cb59335eae2eb93ceb664c0eb7ea6bf567079d843e09420219668e072"
-
-[[package]]
 name = "semver"
 version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1311,18 +1047,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "shlex"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7fdf1b9db47230893d76faad238fd6097fd6d6a9245cd7a4d90dbd639536bbd2"
-
-[[package]]
-name = "shlex"
-version = "1.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
-
-[[package]]
 name = "simba"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1347,12 +1071,6 @@ dependencies = [
  "num-traits",
  "rand",
 ]
-
-[[package]]
-name = "strsim"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
 
 [[package]]
 name = "strsim"
@@ -1428,24 +1146,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "termcolor"
-version = "1.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06794f8f6c5c898b3275aebefa6b8a1cb24cd2c6c79397ab15774837a0bc5755"
-dependencies = [
- "winapi-util",
-]
-
-[[package]]
-name = "textwrap"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d326610f408c7a4eb6f51c37c330e496b08506c9457c9d34287ecc38809fb060"
-dependencies = [
- "unicode-width 0.1.14",
-]
-
-[[package]]
 name = "thiserror"
 version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1485,12 +1185,6 @@ checksum = "5a5f39404a5da50712a4c1eecf25e90dd62b613502b7e925fd4e4d19b5c96512"
 
 [[package]]
 name = "unicode-width"
-version = "0.1.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7dd6e30e90baa6f72411720665d41d89b9a3d039dc45b8faea1ddd07f617f6af"
-
-[[package]]
-name = "unicode-width"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4a1a07cc7db3810833284e8d372ccdc6da29741639ecc70c9ec107df0fa6154c"
@@ -1509,12 +1203,6 @@ checksum = "f1bddf1187be692e79c5ffeab891132dfb0f236ed36a43c7ed39f1165ee20191"
 dependencies = [
  "serde",
 ]
-
-[[package]]
-name = "version_check"
-version = "0.9.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "wasi"
@@ -1537,7 +1225,7 @@ version = "0.2.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1edc8929d7499fc4e8f0be2262a241556cfc54a0bea223790e71446f2aab1ef5"
 dependencies = [
- "cfg-if 1.0.1",
+ "cfg-if",
  "once_cell",
  "wasm-bindgen-macro",
 ]
@@ -1599,15 +1287,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "which"
-version = "3.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d011071ae14a2f6671d0b74080ae0cd8ebf3a6f8c9589a2cd45f23126fe29724"
-dependencies = [
- "libc",
-]
-
-[[package]]
 name = "wide"
 version = "0.7.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1632,15 +1311,6 @@ name = "winapi-i686-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
-
-[[package]]
-name = "winapi-util"
-version = "0.1.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
-dependencies = [
- "windows-sys",
-]
 
 [[package]]
 name = "winapi-x86_64-pc-windows-gnu"
@@ -1727,16 +1397,7 @@ version = "0.39.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6f42320e61fe2cfd34354ecb597f86f413484a798ba44a8ca1165c58d42da6c1"
 dependencies = [
- "bitflags 2.9.1",
-]
-
-[[package]]
-name = "xz2"
-version = "0.1.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "388c44dc09d76f1536602ead6d325eb532f5c122f17782bd57fb47baeeb767e2"
-dependencies = [
- "lzma-sys",
+ "bitflags",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -598,7 +598,7 @@ checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 [[package]]
 name = "lib_wfa2"
 version = "0.1.0"
-source = "git+https://github.com/ekg/lib_wfa2?branch=eg%2Flibrary-only-build#435901c88704a68a80a476b07667579f16360df9"
+source = "git+https://github.com/ekg/lib_wfa2?rev=28f4c67ed93979c9114b55dc7ebc58376af09c04#28f4c67ed93979c9114b55dc7ebc58376af09c04"
 
 [[package]]
 name = "libc"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -598,7 +598,7 @@ checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 [[package]]
 name = "lib_wfa2"
 version = "0.1.0"
-source = "git+https://github.com/ekg/lib_wfa2?rev=819b82cd842aabedcb962fd5b82380fe454234f6#819b82cd842aabedcb962fd5b82380fe454234f6"
+source = "git+https://github.com/ekg/lib_wfa2?branch=eg%2Flibrary-only-build#435901c88704a68a80a476b07667579f16360df9"
 
 [[package]]
 name = "libc"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ clap = { version = "4.4", features = ["derive"] }
 indicatif = { version = "0.17", features = ["rayon"] }
 # faigz-rs = { git = "https://github.com/waveygang/faigz-rs.git", rev = "06799b07bfca219f4eef844b43f7d8c3ef5f3d6f" }
 noodles = { version = "0.94", features = ["fasta", "bgzf"] }
-lib_wfa2 = { git = "https://github.com/ekg/lib_wfa2", branch = "eg/library-only-build" }
+lib_wfa2 = { git = "https://github.com/ekg/lib_wfa2", rev = "28f4c67ed93979c9114b55dc7ebc58376af09c04" }
 rand = "0.8"
 rayon = "1.8"
 tempfile = "3.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ clap = { version = "4.4", features = ["derive"] }
 indicatif = { version = "0.17", features = ["rayon"] }
 # faigz-rs = { git = "https://github.com/waveygang/faigz-rs.git", rev = "06799b07bfca219f4eef844b43f7d8c3ef5f3d6f" }
 noodles = { version = "0.94", features = ["fasta", "bgzf"] }
-lib_wfa2 = { git = "https://github.com/ekg/lib_wfa2", rev = "819b82cd842aabedcb962fd5b82380fe454234f6" }
+lib_wfa2 = { git = "https://github.com/ekg/lib_wfa2", branch = "eg/library-only-build" }
 rand = "0.8"
 rayon = "1.8"
 tempfile = "3.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,6 @@ path = "src/main.rs"
 [dependencies]
 bio = "1.4"
 clap = { version = "4.4", features = ["derive"] }
-edlib_rs = { version = "0.1", optional = true }
 indicatif = { version = "0.17", features = ["rayon"] }
 # faigz-rs = { git = "https://github.com/waveygang/faigz-rs.git", rev = "06799b07bfca219f4eef844b43f7d8c3ef5f3d6f" }
 noodles = { version = "0.94", features = ["fasta", "bgzf"] }
@@ -80,7 +79,6 @@ path = "tests/debug/verify_memory_mode.rs"
 required-features = ["debug-bins"]
 
 [features]
-default = ["edlib-orientation"]
-edlib-orientation = ["edlib_rs"]
+default = []
 # Feature flag to enable debug binaries
 debug-bins = []

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ path = "src/main.rs"
 [dependencies]
 bio = "1.4"
 clap = { version = "4.4", features = ["derive"] }
-edlib_rs = "0.1"
+edlib_rs = { version = "0.1", optional = true }
 indicatif = { version = "0.17", features = ["rayon"] }
 # faigz-rs = { git = "https://github.com/waveygang/faigz-rs.git", rev = "06799b07bfca219f4eef844b43f7d8c3ef5f3d6f" }
 noodles = { version = "0.94", features = ["fasta", "bgzf"] }
@@ -80,5 +80,7 @@ path = "tests/debug/verify_memory_mode.rs"
 required-features = ["debug-bins"]
 
 [features]
+default = ["edlib-orientation"]
+edlib-orientation = ["edlib_rs"]
 # Feature flag to enable debug binaries
 debug-bins = []

--- a/src/alignment.rs
+++ b/src/alignment.rs
@@ -1,12 +1,11 @@
 //! Core alignment functionality
 
 use crate::types::{AlignmentError, AlignmentMode, AlignmentParams, AlignmentResult, Sequence};
-#[cfg(feature = "edlib-orientation")]
-use edlib_rs::edlibrs::*;
 use lib_wfa2::affine_wavefront::{
     AffineWavefronts, AlignmentScope, AlignmentSpan, AlignmentStatus, HeuristicStrategy, MemoryMode,
 };
 use std::cell::RefCell;
+use std::thread::LocalKey;
 
 thread_local! {
     static WFA_ALIGNER: RefCell<Option<AffineWavefronts>> = const { RefCell::new(None) };
@@ -20,21 +19,14 @@ pub fn align_pair(
     query_idx: usize,
     target_idx: usize,
     params: &AlignmentParams,
-    _orientation_params: &AlignmentParams,
+    orientation_params: &AlignmentParams,
     use_mash_orientation: bool,
 ) -> AlignmentResult {
     // Determine best orientation using selected method
     let (query_seq, is_reverse) = if use_mash_orientation {
         determine_orientation_mash(&query.seq, &target.seq)
     } else {
-        #[cfg(feature = "edlib-orientation")]
-        {
-            determine_orientation_edlib(&query.seq, &target.seq)
-        }
-        #[cfg(not(feature = "edlib-orientation"))]
-        {
-            determine_orientation_mash(&query.seq, &target.seq)
-        }
+        determine_orientation_wfa(&query.seq, &target.seq, orientation_params)
     };
 
     // Perform the actual alignment with WFA2
@@ -152,26 +144,20 @@ fn is_dna_base(b: u8) -> bool {
     matches!(b.to_ascii_uppercase(), b'A' | b'C' | b'G' | b'T')
 }
 
-/// Determine best orientation for alignment using fast edit distance (edlib)
-#[cfg(feature = "edlib-orientation")]
-fn determine_orientation_edlib(query: &[u8], target: &[u8]) -> (Vec<u8>, bool) {
-    let config = EdlibAlignConfigRs {
-        k: -1,                                       // No limit on edit distance
-        mode: EdlibAlignModeRs::EDLIB_MODE_NW,       // Global alignment
-        task: EdlibAlignTaskRs::EDLIB_TASK_DISTANCE, // Just get distance
-        additionalequalities: &[],
-    };
-
-    // Get edit distance for forward orientation
-    let fwd_result = edlibAlignRs(query, target, &config);
-    let fwd_distance = fwd_result.editDistance;
-
-    // Get edit distance for reverse complement orientation
+/// Determine best orientation by running global WFA in both orientations.
+fn determine_orientation_wfa(
+    query: &[u8],
+    target: &[u8],
+    params: &AlignmentParams,
+) -> (Vec<u8>, bool) {
     let rev_seq = reverse_complement(query);
-    let rev_result = edlibAlignRs(&rev_seq, target, &config);
-    let rev_distance = rev_result.editDistance;
+    let fwd_distance = perform_wfa_alignment_with_cache(query, target, params, &WFA_ORIENTATION)
+        .map(|result| edit_distance_from_cigar(&result.cigar_bytes))
+        .unwrap_or(usize::MAX);
+    let rev_distance = perform_wfa_alignment_with_cache(&rev_seq, target, params, &WFA_ORIENTATION)
+        .map(|result| edit_distance_from_cigar(&result.cigar_bytes))
+        .unwrap_or(usize::MAX);
 
-    // Choose the better orientation
     if fwd_distance <= rev_distance {
         (query.to_vec(), false)
     } else {
@@ -200,10 +186,19 @@ fn perform_wfa_alignment(
     target: &[u8],
     params: &AlignmentParams,
 ) -> Result<AlignmentResult, AlignmentError> {
+    perform_wfa_alignment_with_cache(query, target, params, &WFA_ALIGNER)
+}
+
+fn perform_wfa_alignment_with_cache(
+    query: &[u8],
+    target: &[u8],
+    params: &AlignmentParams,
+    cache: &'static LocalKey<RefCell<Option<AffineWavefronts>>>,
+) -> Result<AlignmentResult, AlignmentError> {
     let mode = AlignmentMode::from_params(params);
 
     // Create or reuse WFA2 aligner
-    WFA_ALIGNER.with(|aligner_cell| {
+    cache.with(|aligner_cell| {
         let mut aligner_opt = aligner_cell.borrow_mut();
 
         let wf = match &mut *aligner_opt {
@@ -303,6 +298,13 @@ fn count_cigar_operations(cigar_bytes: &[u8]) -> (usize, usize) {
     }
 
     (matches, alignment_length)
+}
+
+fn edit_distance_from_cigar(cigar_bytes: &[u8]) -> usize {
+    cigar_bytes
+        .iter()
+        .filter(|&&op| matches!(op, b'X' | b'I' | b'D'))
+        .count()
 }
 
 /// Parse CIGAR to get alignment lengths

--- a/src/alignment.rs
+++ b/src/alignment.rs
@@ -1,6 +1,7 @@
 //! Core alignment functionality
 
 use crate::types::{AlignmentError, AlignmentMode, AlignmentParams, AlignmentResult, Sequence};
+#[cfg(feature = "edlib-orientation")]
 use edlib_rs::edlibrs::*;
 use lib_wfa2::affine_wavefront::{
     AffineWavefronts, AlignmentScope, AlignmentSpan, AlignmentStatus, HeuristicStrategy, MemoryMode,
@@ -26,7 +27,14 @@ pub fn align_pair(
     let (query_seq, is_reverse) = if use_mash_orientation {
         determine_orientation_mash(&query.seq, &target.seq)
     } else {
-        determine_orientation_edlib(&query.seq, &target.seq)
+        #[cfg(feature = "edlib-orientation")]
+        {
+            determine_orientation_edlib(&query.seq, &target.seq)
+        }
+        #[cfg(not(feature = "edlib-orientation"))]
+        {
+            determine_orientation_mash(&query.seq, &target.seq)
+        }
     };
 
     // Perform the actual alignment with WFA2
@@ -145,6 +153,7 @@ fn is_dna_base(b: u8) -> bool {
 }
 
 /// Determine best orientation for alignment using fast edit distance (edlib)
+#[cfg(feature = "edlib-orientation")]
 fn determine_orientation_edlib(query: &[u8], target: &[u8]) -> (Vec<u8>, bool) {
     let config = EdlibAlignConfigRs {
         k: -1,                                       // No limit on edit distance

--- a/src/knn_graph.rs
+++ b/src/knn_graph.rs
@@ -6,6 +6,8 @@
 
 use crate::types::Sequence;
 
+type PairList = Vec<(usize, usize)>;
+
 /// Extract sequence pairs using k-nearest neighbor graph with optional stranger-joining
 pub fn extract_tree_pairs(
     sequences: &[Sequence],
@@ -57,7 +59,7 @@ pub fn extract_tree_pairs_separated(
     k_farthest: usize,
     random_fraction: f64,
     kmer_size: usize,
-) -> (Vec<(usize, usize)>, Vec<(usize, usize)>) {
+) -> (PairList, PairList) {
     if sequences.len() < 2 {
         return (Vec::new(), Vec::new());
     }
@@ -91,7 +93,7 @@ pub fn extract_tree_pairs_separated(
     };
 
     // Remove any random pairs that are already in tree pairs
-    random_pairs.retain(|pair| !tree_pairs.binary_search(pair).is_ok());
+    random_pairs.retain(|pair| tree_pairs.binary_search(pair).is_err());
 
     (tree_pairs, random_pairs)
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -66,9 +66,9 @@ struct Args {
     #[arg(long)]
     mash_matrix: bool,
 
-    /// Use edlib edit distance for orientation detection instead of mash
+    /// Use WFA edit distance for orientation detection instead of mash
     #[arg(long)]
-    edlib_orientation: bool,
+    wfa_orientation: bool,
 
     /// Keep only sequences whose IDs start with any of these prefixes (comma-separated list)
     #[arg(short = 'k', long, conflicts_with = "exclude_prefixes")]
@@ -310,7 +310,7 @@ fn main() -> io::Result<()> {
         &sequences,
         params,
         true,
-        !args.edlib_orientation,
+        !args.wfa_orientation,
         sparsification,
     );
 

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -864,7 +864,7 @@ fn parse_identity(fields: &[&str]) -> f64 {
 
 #[test]
 fn test_orientation_detection_comparison() {
-    println!("\n=== Test: Mash vs Edlib orientation detection comparison ===");
+    println!("\n=== Test: Mash vs WFA orientation detection comparison ===");
 
     // Create test sequences with known orientations
     let test_cases = create_orientation_test_cases();
@@ -875,8 +875,8 @@ fn test_orientation_detection_comparison() {
         // Test mash-based orientation detection
         let mash_result = test_orientation_detection_mash(&test_case);
 
-        // Test edlib-based orientation detection
-        let edlib_result = test_orientation_detection_edlib(&test_case);
+        // Test WFA-based orientation detection
+        let wfa_result = test_orientation_detection_wfa(&test_case);
 
         println!(
             "    Mash result: forward={:.4}, reverse={:.4}, chose={}",
@@ -889,10 +889,10 @@ fn test_orientation_detection_comparison() {
             }
         );
         println!(
-            "    Edlib result: forward={}, reverse={}, chose={}",
-            edlib_result.forward_distance,
-            edlib_result.reverse_distance,
-            if edlib_result.is_reverse {
+            "    WFA result: forward={}, reverse={}, chose={}",
+            wfa_result.forward_distance,
+            wfa_result.reverse_distance,
+            if wfa_result.is_reverse {
                 "reverse"
             } else {
                 "forward"
@@ -901,7 +901,7 @@ fn test_orientation_detection_comparison() {
 
         // Both methods should agree on orientation
         assert_eq!(
-            mash_result.is_reverse, edlib_result.is_reverse,
+            mash_result.is_reverse, wfa_result.is_reverse,
             "Orientation detection methods disagree for test case: {}",
             test_case.name
         );
@@ -913,8 +913,8 @@ fn test_orientation_detection_comparison() {
             test_case.name
         );
         assert_eq!(
-            edlib_result.is_reverse, test_case.expected_reverse,
-            "Edlib orientation detection incorrect for test case: {}",
+            wfa_result.is_reverse, test_case.expected_reverse,
+            "WFA orientation detection incorrect for test case: {}",
             test_case.name
         );
     }
@@ -1140,24 +1140,33 @@ fn is_dna_base_test(b: u8) -> bool {
     matches!(b.to_ascii_uppercase(), b'A' | b'C' | b'G' | b'T')
 }
 
-fn test_orientation_detection_edlib(test_case: &OrientationTestCase) -> OrientationResult {
-    use edlib_rs::edlibrs::*;
-
-    let config = EdlibAlignConfigRs {
-        k: -1,
-        mode: EdlibAlignModeRs::EDLIB_MODE_NW,
-        task: EdlibAlignTaskRs::EDLIB_TASK_DISTANCE,
-        additionalequalities: &[],
+fn test_orientation_detection_wfa(test_case: &OrientationTestCase) -> OrientationResult {
+    let penalties = allwave::wfa::Penalties {
+        mismatch: 1,
+        gap_opening1: 1,
+        gap_extension1: 1,
+        gap_opening2: 1,
+        gap_extension2: 1,
     };
 
-    // Get edit distance for forward orientation
-    let fwd_result = edlibAlignRs(&test_case.query, &test_case.reference, &config);
-    let fwd_distance = fwd_result.editDistance;
+    let fwd_distance = allwave::wfa::align_sequences(
+        &test_case.query,
+        &test_case.reference,
+        &penalties,
+        allwave::wfa::AlignmentMode::EditDistance,
+    )
+    .map(|result| result.mismatches + result.insertions + result.deletions)
+    .unwrap_or(usize::MAX);
 
-    // Get edit distance for reverse complement orientation
     let rev_seq = reverse_complement(&test_case.query);
-    let rev_result = edlibAlignRs(&rev_seq, &test_case.reference, &config);
-    let rev_distance = rev_result.editDistance;
+    let rev_distance = allwave::wfa::align_sequences(
+        &rev_seq,
+        &test_case.reference,
+        &penalties,
+        allwave::wfa::AlignmentMode::EditDistance,
+    )
+    .map(|result| result.mismatches + result.insertions + result.deletions)
+    .unwrap_or(usize::MAX);
 
     OrientationResult {
         forward_distance: fwd_distance as f64,
@@ -1198,23 +1207,20 @@ fn test_orientation_detection_performance() {
         let mash_result = test_orientation_detection_mash(&test_case);
         let mash_time = start.elapsed();
 
-        // Time edlib-based detection
+        // Time WFA-based detection
         let start = Instant::now();
-        let edlib_result = test_orientation_detection_edlib(&test_case);
-        let edlib_time = start.elapsed();
+        let wfa_result = test_orientation_detection_wfa(&test_case);
+        let wfa_time = start.elapsed();
 
+        println!("    Mash time: {:?}, WFA time: {:?}", mash_time, wfa_time);
         println!(
-            "    Mash time: {:?}, Edlib time: {:?}",
-            mash_time, edlib_time
-        );
-        println!(
-            "    Mash result: {}, Edlib result: {}",
+            "    Mash result: {}, WFA result: {}",
             if mash_result.is_reverse {
                 "reverse"
             } else {
                 "forward"
             },
-            if edlib_result.is_reverse {
+            if wfa_result.is_reverse {
                 "reverse"
             } else {
                 "forward"
@@ -1223,7 +1229,7 @@ fn test_orientation_detection_performance() {
 
         // Both should agree on orientation
         assert_eq!(
-            mash_result.is_reverse, edlib_result.is_reverse,
+            mash_result.is_reverse, wfa_result.is_reverse,
             "Methods disagree for length {}",
             length
         );


### PR DESCRIPTION
## Summary

- Remove the edlib_rs dependency and edlib orientation path entirely
- Keep Mash orientation as the fast default path
- Add WFA edit-distance orientation as the exact fallback path via --wfa-orientation
- Keep all pairwise sequence alignment on lib_wfa2/BiWFA
- Use ekg/lib_wfa2 PR #1 so CI builds only the WFA static library instead of OpenMP-dependent WFA2 tools/examples
- Fix two Clippy findings in the pair-sampling code

## Motivation

AllWave should not pull edlib into the graph-crush path. impg needs AllWave as an in-process many-sequence BiWFA backend, and the orientation alternatives should be Mash for speed or WFA for exactness, not edlib.

The lib_wfa2 update fixes macOS CI by avoiding WFA2-lib tools/examples that use a bare -fopenmp flag rejected by Apple clang. The Rust bindings only need libwfa.a.

## Validation

- cargo check
- cargo check --no-default-features
- cargo fmt --check
- cargo clippy -- -D warnings
- cargo test --lib -- --nocapture
- cargo test orientation_detection --test integration_tests -- --nocapture
- cargo test --verbose
