### PR TITLE
Update lib_wfa2 to WFA2-lib v2.3.6

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -598,7 +598,7 @@ checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 [[package]]
 name = "lib_wfa2"
 version = "0.1.0"
-source = "git+https://github.com/ekg/lib_wfa2?rev=28f4c67ed93979c9114b55dc7ebc58376af09c04#28f4c67ed93979c9114b55dc7ebc58376af09c04"
+source = "git+https://github.com/ekg/lib_wfa2?rev=df865870fb998d3717b493c00b2b0489e5dac4d3#df865870fb998d3717b493c00b2b0489e5dac4d3"
 
 [[package]]
 name = "libc"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ clap = { version = "4.4", features = ["derive"] }
 indicatif = { version = "0.17", features = ["rayon"] }
 # faigz-rs = { git = "https://github.com/waveygang/faigz-rs.git", rev = "06799b07bfca219f4eef844b43f7d8c3ef5f3d6f" }
 noodles = { version = "0.94", features = ["fasta", "bgzf"] }
-lib_wfa2 = { git = "https://github.com/ekg/lib_wfa2", rev = "28f4c67ed93979c9114b55dc7ebc58376af09c04" }
+lib_wfa2 = { git = "https://github.com/ekg/lib_wfa2", rev = "df865870fb998d3717b493c00b2b0489e5dac4d3" }
 rand = "0.8"
 rayon = "1.8"
 tempfile = "3.0"


### PR DESCRIPTION
## Summary

- Pin lib_wfa2 to merged ekg/lib_wfa2 commit df865870fb998d3717b493c00b2b0489e5dac4d3
- That wrapper commit updates the vendored upstream smarco/WFA2-lib submodule to v2.3.6 / bcf473a
- Keeps AllWave on the real upstream WFA2-lib BiWFA implementation through lib_wfa2

## Validation

- cargo check
- cargo test --lib -- --nocapture
- cargo test orientation_detection --test integration_tests -- --nocapture
