### PR TITLE
Update lib_wfa2 compatibility rev

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -598,7 +598,7 @@ checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 [[package]]
 name = "lib_wfa2"
 version = "0.1.0"
-source = "git+https://github.com/ekg/lib_wfa2?rev=df865870fb998d3717b493c00b2b0489e5dac4d3#df865870fb998d3717b493c00b2b0489e5dac4d3"
+source = "git+https://github.com/ekg/lib_wfa2?rev=2f9d9a48addee5185d8ff6ed0594182558d60818#2f9d9a48addee5185d8ff6ed0594182558d60818"
 
 [[package]]
 name = "libc"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ clap = { version = "4.4", features = ["derive"] }
 indicatif = { version = "0.17", features = ["rayon"] }
 # faigz-rs = { git = "https://github.com/waveygang/faigz-rs.git", rev = "06799b07bfca219f4eef844b43f7d8c3ef5f3d6f" }
 noodles = { version = "0.94", features = ["fasta", "bgzf"] }
-lib_wfa2 = { git = "https://github.com/ekg/lib_wfa2", rev = "df865870fb998d3717b493c00b2b0489e5dac4d3" }
+lib_wfa2 = { git = "https://github.com/ekg/lib_wfa2", rev = "2f9d9a48addee5185d8ff6ed0594182558d60818" }
 rand = "0.8"
 rayon = "1.8"
 tempfile = "3.0"


### PR DESCRIPTION
Pins lib_wfa2 to the merge commit that keeps the WFA2-lib v2.3.6 update while restoring compatibility shims used by downstream crates.\n\nValidation:\n- cargo check\n- cargo test --lib -- --nocapture\n- cargo test orientation_detection --test integration_tests -- --nocapture